### PR TITLE
Fix fast kurtogram error when x read-only

### DIFF
--- a/src/openconmo/kurtogram.py
+++ b/src/openconmo/kurtogram.py
@@ -90,7 +90,7 @@ def fast_kurtogram(x,fs,nlevel=7, verbose=False):
     N2 = np.log2(N) - 7
     if nlevel > N2:
         raise ValueError('Please enter a smaller number of decomposition levels')
-    x -= np.mean(x)
+    x = x - np.mean(x)
     N = 16
     fc = 0.4
     h = firwin(N+1,fc) * np.exp(2j * np.pi * np.arange(N+1) * 0.125)


### PR DESCRIPTION
Getting an `ValueError: output array is read-only`error for the `fast_kurtogram` function. `x` seems to be read-only for some reason. `x = x - np.mean(x)` creates a new `x`instead of modifying the existing one, unlike `x -= np.mean(x)`, meaning there is no problem with immutability.

This could be a new problem caused by some update, but most likely it's because the user supplies an `x` as a parameter that has been made immutable for reasons not related to OpenConMo.